### PR TITLE
Added the fix for Glue Crawler get_partitions where clause 2048 char limit

### DIFF
--- a/dbt/include/athena/macros/materializations/incremental.sql
+++ b/dbt/include/athena/macros/materializations/incremental.sql
@@ -48,9 +48,9 @@
     {%- set single_partition_expression = single_partition | join(' and ') -%}
     {%- do partitions.append('(' + single_partition_expression + ')') -%}
   {%- endfor -%}
-  {%- set partition_expression = partitions | join(' or ') -%}
-  {%- do adapter.clean_up_partitions(target_relation.schema, target_relation.table, partition_expression) -%}
-
+  {%- for i in range(partitions | length) %}
+    {%- do adapter.clean_up_partitions(target_relation.schema, target_relation.table, partitions[i]) -%}
+  {%- endfor -%}
 {%- endmacro %}
 
 {% materialization incremental, adapter='athena' -%}


### PR DESCRIPTION
Added the fix for Glue Crawler get_partitions where clause 2048 char limit

Exception Message - 'expression' failed to satisfy constraint: Member must have length less than or equal to 2048